### PR TITLE
Added GH_Upgrader for automatically replacing obsolete Data parameter

### DIFF
--- a/Bombyx2/Bombyx2/GUI/Common/GenericParameter.cs
+++ b/Bombyx2/Bombyx2/GUI/Common/GenericParameter.cs
@@ -47,6 +47,9 @@ namespace Bombyx2.GUI.Common
         {
             ClearData();
         }
+
+        public override string Name { get => "Data (from Bombyx)"; set => base.Name = value; }
+
         public override GH_Exposure Exposure => GH_Exposure.hidden;
 
         public override Guid ComponentGuid => new Guid("ff9faf9b-fda6-4bd0-9e6e-04c850c7d962");

--- a/Bombyx2/Bombyx2/GUI/Common/GenericParameterUpgrader.cs
+++ b/Bombyx2/Bombyx2/GUI/Common/GenericParameterUpgrader.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using GH_IO.Serialization;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+
+namespace Bombyx2.GUI.Common
+{
+    /// <summary>
+    /// Enables users to replace copies of this obsolete component with the default "Data" component.
+    /// They can do so by choosing "Solution" > "Upgrade Components..." from the topbar menu.
+    /// </summary>
+    public class GenericParameterUpgrader : IGH_UpgradeObject
+    {
+        public DateTime Version => new DateTime(2024, 9, 19);
+
+        public Guid UpgradeFrom => new GenericParameter().ComponentGuid;
+
+        public Guid UpgradeTo => new Param_GenericObject().ComponentGuid;
+
+        public IGH_DocumentObject Upgrade(IGH_DocumentObject target, GH_Document document)
+        {
+            var oldParam = target as GenericParameter;
+            var newParam = new Param_GenericObject();
+            var index = document.Objects.IndexOf(oldParam);
+            GH_UpgradeUtil.MigrateSources(oldParam, newParam);
+            GH_UpgradeUtil.MigrateRecipients(oldParam, newParam);
+            newParam.CreateAttributes();
+            newParam.Attributes.Pivot = oldParam.Attributes.Pivot;
+            newParam.NickName = oldParam.NickName;
+            newParam.Attributes.ExpireLayout();
+            document.DestroyAttributeCache();
+            document.DestroyObjectTable();
+            document.RemoveObject(oldParam, false);
+            document.AddObject(newParam, false, index);
+            return newParam;
+        }
+    }
+}


### PR DESCRIPTION
This change enables users to replace copies of the obsolete duplicate of "Data" component with the default "Data" component.
They can do so by choosing "Solution" > "Upgrade Components..." from the topbar menu.

This makes it easy to fix a common issue with Grasshopper files, where the obsolete Bombyx copy of standard "Data" parameter was used by mistake. Otherwise, such Grasshopper files are not usable without Bombyx2 plugin installed.

Related discussion:
https://discourse.mcneel.com/t/duplicated-data-component-after-installing-a-plugin/132190

![image](https://github.com/user-attachments/assets/9f4d7ff6-0cf3-40ea-b7b9-2498ce876397)
![image](https://github.com/user-attachments/assets/38bc89cf-4ef0-4814-b5ab-283a8d9c264d)